### PR TITLE
README: Add Alternatives and Comparison sections.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,6 @@ vfsgen is open source, thanks for considering contributing!
 
 Please note that vfsgen aims to be simple and minimalistic, with as little to configure as possible. If you'd like to remove or simplify code (while having tests continue to pass), fix bugs, or improve code (e.g., add missing error checking, etc.), PRs and issues are welcome.
 
-However, if you'd like to add new functionality that increases complexity or scope, please make an issue and discuss your proposal first. I'm unlikely to accept such changes outright. It might be that your request is already a part of either go-bindata and/or go-bindata-assetfs, or it might fit in their scope better.
+However, if you'd like to add new functionality that increases complexity or scope, please make an issue and discuss your proposal first. I'm unlikely to accept such changes outright. It might be that your request is already a part of other similar packages, or it might fit in their scope better. See [Comparison and Alternatives](https://github.com/shurcooL/vfsgen/tree/README-alternatives-and-comparison-section#comparison) sections.
 
 Thank you!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # vfsgen [![Build Status](https://travis-ci.org/shurcooL/vfsgen.svg?branch=master)](https://travis-ci.org/shurcooL/vfsgen) [![GoDoc](https://godoc.org/github.com/shurcooL/vfsgen?status.svg)](https://godoc.org/github.com/shurcooL/vfsgen)
 
-Package vfsgen generates a vfsdata.go file that statically implements the given virtual filesystem.
-
-vfsgen is simple and minimalistic. You provide an input filesystem, and it generates an output .go file.
+Package vfsgen takes an input http.FileSystem (likely at `go generate` time) and
+generates Go code that statically implements the given http.FileSystem.
 
 Features:
 
@@ -78,19 +77,21 @@ interface {
 Comparison
 ----------
 
-Compared to other similar tools, vfsgen is simple and minimalistic. Its simplicity comes from relying on [`http.FileSystem`](https://godoc.org/net/http#FileSystem) abstraction as both input and output in generated code. That makes it easy to plug in to your code, especially if you're already using `http.FileSystem` implementations.
+vfsgen aims to be conceptually simple to use. The [`http.FileSystem`](https://godoc.org/net/http#FileSystem) abstraction is central to vfsgen. It's used as both input for code generation, and as output in the generated code.
+
+That enables great flexibility through orthogonality, since helpers and wrappers can operate on `http.FileSystem` without knowing about vfsgen. If you want, you can perform pre-processing, minifying assets, merging folders, filtering out files and otherwise modifying input via generic `http.FileSystem` middleware.
 
 It avoids unneccessary overhead by merging what was previously done with two distinct packages into a single package.
 
-It aims to be the best in its class in terms of code quality and efficiency of generated code. However, if your use goals are different, there are other similar packages that may fit your needs better.
+It strives to be the best in its class in terms of code quality and efficiency of generated code. However, if your use goals are different, there are other similar packages that may fit your needs better.
 
 ### Alternatives
 
 -	[`go-bindata`](https://github.com/jteeuwen/go-bindata) - Reads from disk, generates Go code that provides access to data via a [custom interface](https://github.com/jteeuwen/go-bindata#accessing-an-asset).
 -	[`go-bindata-assetfs`](https://github.com/elazarl/go-bindata-assetfs) - Takes output of go-bindata and provides a wrapper that implements `http.FileSystem` interface (the same as what vfsgen outputs directly).
 -	[`becky`](https://github.com/tv42/becky) - Embeds assets as string literals in Go source.
--	[`statik`](https://github.com/rakyll/statik) - Embeds a directory of static files to be accessed via `http.FileSystem` interface (sounds very similar to vfsgen); implementation sourced from from [camlistore](https://camlistore.org).
--	[`go.rice`](https://github.com/GeertJohan/go.rice) - Makes working with resources such as html, js, css, images and templates very easy.
+-	[`statik`](https://github.com/rakyll/statik) - Embeds a directory of static files to be accessed via `http.FileSystem` interface (sounds very similar to vfsgen); implementation sourced from [camlistore](https://camlistore.org).
+-	[`go.rice`](https://github.com/GeertJohan/go.rice) - Makes working with resources such as HTML, JS, CSS, images and templates very easy.
 
 Attribution
 -----------

--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ interface {
 }
 ```
 
+Comparison
+----------
+
+Compared to other similar tools, vfsgen is simple and minimalistic. Its simplicity comes from relying on [`http.FileSystem`](https://godoc.org/net/http#FileSystem) abstraction as both input and output in generated code. That makes it easy to plug in to your code, especially if you're already using `http.FileSystem` implementations.
+
+It avoids unneccessary overhead by merging what was previously done with two distinct packages into a single package.
+
+It aims to be the best in its class in terms of code quality and efficiency of generated code. However, if your use goals are different, there are other similar packages that may fit your needs better.
+
+### Alternatives
+
+-	[`go-bindata`](https://github.com/jteeuwen/go-bindata) - Reads from disk, generates Go code that provides access to data via a [custom interface](https://github.com/jteeuwen/go-bindata#accessing-an-asset).
+-	[`go-bindata-assetfs`](https://github.com/elazarl/go-bindata-assetfs) - Takes output of go-bindata and provides a wrapper that implements `http.FileSystem` interface (the same as what vfsgen outputs directly).
+-	[`becky`](https://github.com/tv42/becky) - Embeds assets as string literals in Go source.
+-	[`statik`](https://github.com/rakyll/statik) - Embeds a directory of static files to be accessed via `http.FileSystem` interface (sounds very similar to vfsgen); implementation sourced from from [camlistore](https://camlistore.org).
+-	[`go.rice`](https://github.com/GeertJohan/go.rice) - Makes working with resources such as html, js, css, images and templates very easy.
+
 Attribution
 -----------
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ It strives to be the best in its class in terms of code quality and efficiency o
 
 ### Alternatives
 
--	[`go-bindata`](https://github.com/jteeuwen/go-bindata) - Reads from disk, generates Go code that provides access to data via a [custom interface](https://github.com/jteeuwen/go-bindata#accessing-an-asset).
+-	[`go-bindata`](https://github.com/jteeuwen/go-bindata) - Reads from disk, generates Go code that provides access to data via a [custom API](https://github.com/jteeuwen/go-bindata#accessing-an-asset).
 -	[`go-bindata-assetfs`](https://github.com/elazarl/go-bindata-assetfs) - Takes output of go-bindata and provides a wrapper that implements `http.FileSystem` interface (the same as what vfsgen outputs directly).
 -	[`becky`](https://github.com/tv42/becky) - Embeds assets as string literals in Go source.
 -	[`statik`](https://github.com/rakyll/statik) - Embeds a directory of static files to be accessed via `http.FileSystem` interface (sounds very similar to vfsgen); implementation sourced from [camlistore](https://camlistore.org).

--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,6 @@
 /*
-Package vfsgen generates a vfsdata.go file that statically implements the given virtual filesystem.
-
-vfsgen is simple and minimalistic. You provide an input filesystem, and it generates an output .go file.
+Package vfsgen takes an input http.FileSystem (likely at `go generate` time) and
+generates Go code that statically implements the given http.FileSystem.
 
 Features:
 


### PR DESCRIPTION
I've gotten this idea from someone on Twitter (I couldn't find the exact tweet, sadly). It went something like this:

> From now on, all my Go library READMEs will include an Alternatives section!

I think it's a great idea for the following reasons:

- This is good for users because they can either be more confident that vfsgen is the best choice for them, or if their needs are different, find a more well-suited package.

- It's good for vfsgen because it communicates to users more clearly that it is indeed similar to some other existing packages.

- It's good for alternative packages listed because they get free advertisement and exposure.

- It's good for everyone because it can help reduce duplication of effort if something can be consolidated, and improved code quality and functionality due to competition. :)

A great example of 2 packages that already do this is:

- https://github.com/dchest/htmlmin#alternatives - A simple HTML minifier.
- https://github.com/tdewolff/minify#alternatives - A more complete, heavyweight solution for minifying HTML, CSS, JS, JSON, SVG, XML.

I am including some alternative/similar Go libraries that I am aware of. Most of them differ in scope or preferred API for input/output to various degrees.

/cc @jteeuwen @elazarl @tv42 @rakyll @GeertJohan I mentioned your packages in the alternatives section, please let me know if you have a problem with that and would want me to edit it or remove your package, I will gladly do that.

#### Motivation to create vfsgen

I originally made vfsgen after using go-bindata+go-bindata-assetfs for a while but they suffered from https://github.com/jteeuwen/go-bindata/issues/22, https://github.com/elazarl/go-bindata-assetfs/issues/24  and I saw no way to resolve those issues easily without changing the interface significantly (see my proposal for fork [here](https://github.com/jteeuwen/go-bindata/issues/75)).

I also wanted to have the freedom to experiment without being tied to a stable API and see what the best solution in this space is. And I wanted to simplify the code a lot, because I saw a lot of opportunities for that in the original codebases.

I'm very happy with where vfsgen ended up and it enabled me to do things I couldn't otherwise (e.g., see https://github.com/shurcooL/Go-Package-Store/pull/18#issuecomment-120696770). It's useful to me, and I hope it'll be useful to more people who have similar needs. Together with the alternative packages, this problem space in Go has great coverage now.