### PR TITLE
Mimic http.Dir behavior and clean path in Open.

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -250,6 +250,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	pathpkg "path"
 	"time"
 )
 
@@ -312,7 +313,7 @@ var ⦗⦗.VariableName⦘⦘ = func() http.FileSystem {
 type _vfsgen_fs map[string]interface{}
 
 func (fs _vfsgen_fs) Open(path string) (http.File, error) {
-	// TODO: Maybe clean path?
+	path = pathpkg.Clean("/" + path)
 	f, ok := fs[path]
 	if !ok {
 		return nil, &os.PathError{Op: "open", Path: path, Err: os.ErrNotExist}

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -327,9 +327,14 @@ func ExampleNotExist() {
 func ExamplePathCleaned() {
 	var fs http.FileSystem = assets
 
-	_, err := fs.Open("//folderB/../folderA/file1.txt")
+	f, err := fs.Open("//folderB/../folderA/file1.txt")
 	fmt.Println(err)
+
+	if fi, err := f.Stat(); err == nil {
+		fmt.Println(fi.Name())
+	}
 
 	// Output:
 	// <nil>
+	// file1.txt
 }

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -323,3 +323,13 @@ func ExampleNotExist() {
 	// os.IsNotExist: true
 	// open /does-not-exist: file does not exist
 }
+
+func ExamplePathCleaned() {
+	var fs http.FileSystem = assets
+
+	_, err := fs.Open("//folderB/../folderA/file1.txt")
+	fmt.Println(err)
+
+	// Output:
+	// <nil>
+}

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -328,13 +328,17 @@ func ExamplePathCleaned() {
 	var fs http.FileSystem = assets
 
 	f, err := fs.Open("//folderB/../folderA/file1.txt")
-	fmt.Println(err)
-
-	if fi, err := f.Stat(); err == nil {
-		fmt.Println(fi.Name())
+	if err != nil {
+		panic(err)
 	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(fi.Name())
 
 	// Output:
-	// <nil>
 	// file1.txt
 }

--- a/test/test_vfsdata_test.go
+++ b/test/test_vfsdata_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	pathpkg "path"
 	"time"
 )
 
@@ -91,7 +92,7 @@ var assets = func() http.FileSystem {
 type _vfsgen_fs map[string]interface{}
 
 func (fs _vfsgen_fs) Open(path string) (http.File, error) {
-	// TODO: Maybe clean path?
+	path = pathpkg.Clean("/" + path)
 	f, ok := fs[path]
 	if !ok {
 		return nil, &os.PathError{Op: "open", Path: path, Err: os.ErrNotExist}


### PR DESCRIPTION
This change makes the generated VFS compatible in behavior with `http.Dir`.

-	Behaves more in line with `os.Open` and `http.Dir.Open`.
-	Allows unclean paths like "/folder/../file.txt" to resolve.
-	Allows relative paths like "file.txt" to work. But the canonical paths remain absolute like "/file.txt".

Resolves #10.