### PR TITLE
Make the VariableName option default to being exported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ go get -u github.com/shurcooL/vfsgen
 Usage
 -----
 
-This code will generate an assets_vfsdata.go file with `var assets http.FileSystem = ...` that statically implements the contents of "assets" directory.
+This code will generate an assets_vfsdata.go file with `var Assets http.FileSystem = ...` that statically implements the contents of "assets" directory.
 
 ```Go
 var fs http.FileSystem = http.Dir("assets")
@@ -34,16 +34,16 @@ if err != nil {
 }
 ```
 
-Then, in your program, you can use `assets` as any other [`http.FileSystem`](https://godoc.org/net/http#FileSystem), for example:
+Then, in your program, you can use `Assets` as any other [`http.FileSystem`](https://godoc.org/net/http#FileSystem), for example:
 
 ```Go
-file, err := assets.Open("/some/file.txt")
+file, err := Assets.Open("/some/file.txt")
 if err != nil { ... }
 defer file.Close()
 ```
 
 ```Go
-http.Handle("/assets/", http.FileServer(assets))
+http.Handle("/assets/", http.FileServer(Assets))
 ```
 
 ### `go generate` Usage

--- a/generator_test.go
+++ b/generator_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // This code will generate an assets_vfsdata.go file with
-// `var assets http.FileSystem = ...`
+// `var Assets http.FileSystem = ...`
 // that statically implements the contents of "assets" directory.
 //
 // vfsgen is great to use with go generate directives. This code can go in an assets_gen.go file, which can

--- a/options.go
+++ b/options.go
@@ -30,7 +30,7 @@ func (opt *Options) fillMissing() {
 		opt.PackageName = "main"
 	}
 	if opt.VariableName == "" {
-		opt.VariableName = "assets"
+		opt.VariableName = "Assets"
 	}
 	if opt.Filename == "" {
 		opt.Filename = fmt.Sprintf("%s_vfsdata.go", strings.ToLower(opt.VariableName))


### PR DESCRIPTION
This change makes the VariableName default to the exported `Assets` instead of
the previously unexported `assets`. The rational for this is that people creating
Go packages will not have to specify a VariableName parameter at all because it
will default to being exported. For creators of `main` packages, they cannot be
imported anyway so keeping the field private by default is less valuable.