### PR TITLE
Add ./cmd/vfsgendev binary to address common use case.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,68 @@ http.Handle("/assets/", http.FileServer(assets))
 
 ### `go generate` Usage
 
-vfsgen is great to use with go generate directives. The code above can go in an assets_gen.go file, which can then be invoked via "//go:generate go run assets_gen.go". The input virtual filesystem can read directly from disk, or it can be more involved.
+vfsgen is great to use with go generate directives. The code invoking `vfsgen.Generate` can go in an assets_generate.go file, which can then be invoked via "//go:generate go run assets_generate.go". The input virtual filesystem can read directly from disk, or it can be more involved.
 
 By using build tags, you can create a development mode where assets are loaded directly from disk via `http.Dir`, but then statically implemented for final releases.
 
-See [shurcooL/Go-Package-Store#38](https://github.com/shurcooL/Go-Package-Store/pull/38) for a complete example of such use.
+For example, suppose your source filesystem is defined in a package with import path "example.com/project/data" as:
+
+```Go
+// +build dev
+
+package data
+
+// Assets contains project assets.
+var Assets http.FileSystem = http.Dir("assets")
+```
+
+When built with the "dev" build tag, accessing `data.Assets` will read from disk directly via `http.Dir`.
+
+A generate helper file assets_generate.go can be invoked via "//go:generate go run -tags=dev assets_generate.go" directive:
+
+```Go
+// +build ignore
+
+package main
+
+import (
+	"log"
+
+	"example.com/project/data"
+	"github.com/shurcooL/vfsgen"
+)
+
+func main() {
+	err := vfsgen.Generate(data.Assets, vfsgen.Options{
+		PackageName:  "data",
+		BuildTags:    "!dev",
+		VariableName: "Assets",
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+```
+
+Note that "dev" build tag is used to access the source filesystem, and the output file will contain "!dev" build tag. That way, the statically implemented version will be used during normal builds and `go get`, when custom builds tags are not specified.
+
+### `vfsgendev` Usage
+
+`vfsgendev` is a binary that can be used to replace the need for the assets_generate.go file.
+
+Make sure it's installed and available in your PATH.
+
+```bash
+go get -u github.com/shurcooL/vfsgen/cmd/vfsgendev
+```
+
+Then the "//go:generate go run -tags=dev assets_generate.go" directive can be replaced with:
+
+```
+//go:generate vfsgendev -source="example.com/project/data".Assets
+```
+
+vfsgendev accesses the source variable using "dev" build tag, and generates an output file with "!dev" build tag.
 
 ### Additional Embedded Information
 

--- a/cmd/vfsgendev/generate.go
+++ b/cmd/vfsgendev/generate.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"text/template"
+)
+
+type data struct {
+	source
+}
+
+func (data) BuildTags() string { return outputTags }
+
+var generateTemplate = template.Must(template.New("").Funcs(template.FuncMap{
+	"quote": func(s string) string {
+		return strconv.Quote(s)
+	},
+}).Parse(generateTemplateText))
+
+// run runs Go code src with build tags.
+func run(src string, tags string) error {
+	// Create a temp folder.
+	tempDir, err := ioutil.TempDir("", "vfsgendev_")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := os.RemoveAll(tempDir)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "warning: error removing temp dir:", err)
+		}
+	}()
+
+	// Write the source code file.
+	tempFile := filepath.Join(tempDir, "generate.go")
+	err = ioutil.WriteFile(tempFile, []byte(src), 0600)
+	if err != nil {
+		return err
+	}
+
+	// Compile and run the program.
+	cmd := exec.Command("go", "run", "-tags="+tags, tempFile)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/cmd/vfsgendev/parse.go
+++ b/cmd/vfsgendev/parse.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+)
+
+type source struct {
+	ImportPath   string
+	PackageName  string
+	VariableName string
+}
+
+var errInvalidFormat = errors.New("invalid format")
+
+// parseSourceFlag parses the "-source" flag. It must have "import/path".VariableName format.
+func parseSourceFlag(sourceFlag string) (source, error) {
+	// Parse sourceFlag as a Go expression, albeit a strange one:
+	//
+	// 	"import/path".VariableName
+	//
+	e, err := parser.ParseExpr(sourceFlag)
+	if err != nil {
+		return source{}, errInvalidFormat
+	}
+	se, ok := e.(*ast.SelectorExpr)
+	if !ok {
+		return source{}, errInvalidFormat
+	}
+	importPath, err := stringValue(se.X)
+	if err != nil {
+		return source{}, err
+	}
+	variableName := se.Sel.Name
+
+	// Import package to get its full import path and package name.
+	ctx := build.Default
+	ctx.BuildTags = strings.Fields(sourceTags)
+	bpkg, err := ctx.Import(importPath, ".", 0)
+	if err != nil {
+		return source{}, fmt.Errorf("can't import package %q: %v", importPath, err)
+	}
+
+	return source{
+		ImportPath:   bpkg.ImportPath,
+		PackageName:  bpkg.Name,
+		VariableName: variableName,
+	}, nil
+}
+
+// stringValue returns the string value of string literal e.
+func stringValue(e ast.Expr) (string, error) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok {
+		return "", errInvalidFormat
+	}
+	if lit.Kind != token.STRING {
+		return "", errInvalidFormat
+	}
+	return strconv.Unquote(lit.Value)
+}

--- a/cmd/vfsgendev/template.go
+++ b/cmd/vfsgendev/template.go
@@ -1,0 +1,23 @@
+package main
+
+const generateTemplateText = `package main
+
+import (
+	"log"
+
+	"github.com/shurcooL/vfsgen"
+
+	{{.ImportPath | quote}}
+)
+
+func main() {
+	err := vfsgen.Generate({{.PackageName}}.{{.VariableName}}, vfsgen.Options{
+		PackageName:  {{.PackageName | quote}},{{with .BuildTags}}
+		BuildTags:    {{. | quote}},{{end}}
+		VariableName: {{.VariableName | quote}},
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+`

--- a/cmd/vfsgendev/vfsgendev.go
+++ b/cmd/vfsgendev/vfsgendev.go
@@ -1,0 +1,188 @@
+// vfsgendev is a convenience tool for using vfsgen in a common development configuration.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+var (
+	sourceFlag = flag.String("source", "", "Specifies the http.FileSystem variable to use as source.")
+	nFlag      = flag.Bool("n", false, "Print the generated source but do not run it.")
+)
+
+const (
+	sourceTags = "dev"
+
+	outputFilename = "data_generate.go"
+	outputTags     = "!dev"
+)
+
+type source struct {
+	ImportPath   string
+	PackageName  string
+	VariableName string
+}
+
+var errInvalidFormat = fmt.Errorf("invalid format")
+
+// parseSourceFlag parses the "-source" flag. It must have "import/path".VariableName format.
+func parseSourceFlag(sourceFlag string) (source, error) {
+	// Parse sourceFlag as a Go expression, albeit a strange one:
+	//
+	// 	"import/path".VariableName
+	//
+	e, err := parser.ParseExpr(sourceFlag)
+	if err != nil {
+		return source{}, errInvalidFormat
+	}
+	se, ok := e.(*ast.SelectorExpr)
+	if !ok {
+		return source{}, errInvalidFormat
+	}
+	importPath, err := stringValue(se.X)
+	if err != nil {
+		return source{}, err
+	}
+	variableName := se.Sel.Name
+
+	// Import package to get its full import path and package name.
+	ctx := build.Default
+	ctx.BuildTags = strings.Fields(sourceTags)
+	bpkg, err := ctx.Import(importPath, ".", 0)
+	if err != nil {
+		return source{}, fmt.Errorf("can't import package %q: %v", importPath, err)
+	}
+
+	return source{
+		ImportPath:   bpkg.ImportPath,
+		PackageName:  bpkg.Name,
+		VariableName: variableName,
+	}, nil
+}
+
+// stringValue returns the string value of string literal e.
+func stringValue(e ast.Expr) (string, error) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok {
+		return "", errInvalidFormat
+	}
+	if lit.Kind != token.STRING {
+		return "", errInvalidFormat
+	}
+	return strconv.Unquote(lit.Value)
+}
+
+var t = template.Must(template.New("").Funcs(template.FuncMap{
+	"quote": func(s string) string {
+		return strconv.Quote(s)
+	},
+}).Parse(`package main
+
+import (
+	"log"
+
+	"github.com/shurcooL/vfsgen"
+
+	{{.ImportPath | quote}}
+)
+
+func main() {
+	err := vfsgen.Generate({{.PackageName}}.{{.VariableName}}, vfsgen.Options{
+		PackageName:  {{.PackageName | quote}},{{with .BuildTags}}
+		BuildTags:    {{. | quote}},{{end}}
+		VariableName: {{.VariableName | quote}},
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+`))
+
+type data struct {
+	source
+}
+
+func (data) BuildTags() string { return outputTags }
+
+// run runs Go code src with build tags.
+func run(src string, tags string) error {
+	// Create a temp folder.
+	tempDir, err := ioutil.TempDir("", "vfsgendev_")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := os.RemoveAll(tempDir)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "warning: error removing temp dir:", err)
+		}
+	}()
+
+	// Write the source code file.
+	tempFile := filepath.Join(tempDir, "generate.go")
+	err = ioutil.WriteFile(tempFile, []byte(src), 0600)
+	if err != nil {
+		return err
+	}
+
+	// Compile and run the program.
+	cmd := exec.Command("go", "run", "-tags="+tags, tempFile)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func gen() error {
+	source, err := parseSourceFlag(*sourceFlag)
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	err = t.Execute(&buf, data{source: source})
+	if err != nil {
+		return err
+	}
+
+	if *nFlag == true {
+		io.Copy(os.Stdout, &buf)
+		return nil
+	}
+
+	err = run(buf.String(), sourceTags)
+	return err
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, `Usage: vfsgendev [flags] -source="import/path".VariableName`)
+	flag.PrintDefaults()
+}
+
+func main() {
+	flag.Usage = usage
+	flag.Parse()
+	if flag.NArg() != 0 {
+		flag.Usage()
+		os.Exit(2)
+		return
+	}
+
+	err := gen()
+	if err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/cmd/vfsgendev/vfsgendev.go
+++ b/cmd/vfsgendev/vfsgendev.go
@@ -5,24 +5,9 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"go/ast"
-	"go/build"
-	"go/parser"
-	"go/token"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"text/template"
-)
-
-var (
-	sourceFlag = flag.String("source", "", "Specifies the http.FileSystem variable to use as source.")
-	nFlag      = flag.Bool("n", false, "Print the generated source but do not run it.")
 )
 
 const (
@@ -32,133 +17,24 @@ const (
 	outputTags     = "!dev"
 )
 
-type source struct {
-	ImportPath   string
-	PackageName  string
-	VariableName string
-}
-
-var errInvalidFormat = fmt.Errorf("invalid format")
-
-// parseSourceFlag parses the "-source" flag. It must have "import/path".VariableName format.
-func parseSourceFlag(sourceFlag string) (source, error) {
-	// Parse sourceFlag as a Go expression, albeit a strange one:
-	//
-	// 	"import/path".VariableName
-	//
-	e, err := parser.ParseExpr(sourceFlag)
-	if err != nil {
-		return source{}, errInvalidFormat
-	}
-	se, ok := e.(*ast.SelectorExpr)
-	if !ok {
-		return source{}, errInvalidFormat
-	}
-	importPath, err := stringValue(se.X)
-	if err != nil {
-		return source{}, err
-	}
-	variableName := se.Sel.Name
-
-	// Import package to get its full import path and package name.
-	ctx := build.Default
-	ctx.BuildTags = strings.Fields(sourceTags)
-	bpkg, err := ctx.Import(importPath, ".", 0)
-	if err != nil {
-		return source{}, fmt.Errorf("can't import package %q: %v", importPath, err)
-	}
-
-	return source{
-		ImportPath:   bpkg.ImportPath,
-		PackageName:  bpkg.Name,
-		VariableName: variableName,
-	}, nil
-}
-
-// stringValue returns the string value of string literal e.
-func stringValue(e ast.Expr) (string, error) {
-	lit, ok := e.(*ast.BasicLit)
-	if !ok {
-		return "", errInvalidFormat
-	}
-	if lit.Kind != token.STRING {
-		return "", errInvalidFormat
-	}
-	return strconv.Unquote(lit.Value)
-}
-
-var t = template.Must(template.New("").Funcs(template.FuncMap{
-	"quote": func(s string) string {
-		return strconv.Quote(s)
-	},
-}).Parse(`package main
-
-import (
-	"log"
-
-	"github.com/shurcooL/vfsgen"
-
-	{{.ImportPath | quote}}
+var (
+	sourceFlag = flag.String("source", "", "Specifies the http.FileSystem variable to use as source.")
+	nFlag      = flag.Bool("n", false, "Print the generated source but do not run it.")
 )
-
-func main() {
-	err := vfsgen.Generate({{.PackageName}}.{{.VariableName}}, vfsgen.Options{
-		PackageName:  {{.PackageName | quote}},{{with .BuildTags}}
-		BuildTags:    {{. | quote}},{{end}}
-		VariableName: {{.VariableName | quote}},
-	})
-	if err != nil {
-		log.Fatalln(err)
-	}
-}
-`))
-
-type data struct {
-	source
-}
-
-func (data) BuildTags() string { return outputTags }
-
-// run runs Go code src with build tags.
-func run(src string, tags string) error {
-	// Create a temp folder.
-	tempDir, err := ioutil.TempDir("", "vfsgendev_")
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err := os.RemoveAll(tempDir)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "warning: error removing temp dir:", err)
-		}
-	}()
-
-	// Write the source code file.
-	tempFile := filepath.Join(tempDir, "generate.go")
-	err = ioutil.WriteFile(tempFile, []byte(src), 0600)
-	if err != nil {
-		return err
-	}
-
-	// Compile and run the program.
-	cmd := exec.Command("go", "run", "-tags="+tags, tempFile)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
 
 func gen() error {
 	source, err := parseSourceFlag(*sourceFlag)
 	if err != nil {
 		return err
 	}
+
 	var buf bytes.Buffer
-	err = t.Execute(&buf, data{source: source})
+	err = generateTemplate.Execute(&buf, data{source: source})
 	if err != nil {
 		return err
 	}
 
-	if *nFlag == true {
+	if *nFlag {
 		io.Copy(os.Stdout, &buf)
 		return nil
 	}


### PR DESCRIPTION
Add an opinionated binary for specialized use. It uses the convention of using "dev" build tag for development mode, and assumes that the source VFS is defined in a "dev" only environment; it uses "!dev" build tag in output _vfsdata.go file.

Usage is simple:

```bash
$ vfsgendev -source="import/path".VariableName
```

Or in a go:generate directive:

```Go
//go:generate vfsgendev -source="import/path".VariableName
```

See sourcegraph/appdash#91 for additional background, motivation, and discussion.

Resolves #2.

Closes #14.

/cc @slimsag