### PR TITLE
Use ioutil.Discard to skip unwanted bytes from io.Reader.

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -255,6 +255,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	pathpkg "path"
@@ -396,7 +397,7 @@ func (f *_vfsgen_compressedFile) Read(p []byte) (n int, err error) {
 	}
 	if f.grPos < f.seekPos {
 		// Fast-forward.
-		_, err = io.ReadFull(f.gr, make([]byte, f.seekPos-f.grPos))
+		_, err = io.CopyN(ioutil.Discard, f.gr, f.seekPos-f.grPos)
 		if err != nil {
 			return 0, err
 		}

--- a/test/test_vfsdata_test.go
+++ b/test/test_vfsdata_test.go
@@ -7,6 +7,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	pathpkg "path"
@@ -168,7 +169,7 @@ func (f *_vfsgen_compressedFile) Read(p []byte) (n int, err error) {
 	}
 	if f.grPos < f.seekPos {
 		// Fast-forward.
-		_, err = io.ReadFull(f.gr, make([]byte, f.seekPos-f.grPos))
+		_, err = io.CopyN(ioutil.Discard, f.gr, f.seekPos-f.grPos)
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
ioutil.Discard implementation implements io.ReaderFrom and uses a pool of black hole byte slices, which should work better (at least when it comes to allocations, not sure about performance for small n).