### PR TITLE
README: add correct net/http import to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ For example, suppose your source filesystem is defined in a package with import 
 
 package data
 
+import "net/http"
+
 // Assets contains project assets.
 var Assets http.FileSystem = http.Dir("assets")
 ```


### PR DESCRIPTION
I was copying this code and noticed it did not compile. Given other bits of information are not omitted (e.g. the package name), I assume that this was a mistake.