### PR TITLE
Add embedfiles to alternatives list

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ It strives to be the best in its class in terms of code quality and efficiency o
 -	[`staticfiles`](https://github.com/bouk/staticfiles) - Allows you to embed a directory of files into your Go binary.
 -	[`togo`](https://github.com/flazz/togo) - Generates a Go source file with a `[]byte` var containing the given file's contents.
 -	[`fileb0x`](https://github.com/UnnoTed/fileb0x) - Simple customizable tool to embed files in Go.
--       [`embedfiles`](https://github.com/leighmcculloch/embedfiles) - Simple tool for embedding files in Go code as a map.
+-	[`embedfiles`](https://github.com/leighmcculloch/embedfiles) - Simple tool for embedding files in Go code as a map.
 
 Attribution
 -----------

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ It strives to be the best in its class in terms of code quality and efficiency o
 -	[`staticfiles`](https://github.com/bouk/staticfiles) - Allows you to embed a directory of files into your Go binary.
 -	[`togo`](https://github.com/flazz/togo) - Generates a Go source file with a `[]byte` var containing the given file's contents.
 -	[`fileb0x`](https://github.com/UnnoTed/fileb0x) - Simple customizable tool to embed files in Go.
+-       [`embedfiles`](https://github.com/leighmcculloch/embedfiles) - Simple tool for embedding files in Go code as a map.
 
 Attribution
 -----------


### PR DESCRIPTION
What
===
Add `embedfiles` to list of alternatives.

Why
===
It's a simple file-in-a-map solution that carries no additional API or http module baggage.