### PR TITLE
cmd/vfsgendev: Run generator in package directory

### DIFF
--- a/cmd/vfsgendev/generate.go
+++ b/cmd/vfsgendev/generate.go
@@ -15,7 +15,9 @@ type data struct {
 
 var generateTemplate = template.Must(template.New("").Funcs(template.FuncMap{
 	"quote": strconv.Quote,
-}).Parse(`package main
+}).Parse(`// +build ignore
+
+package main
 
 import (
 	"log"


### PR DESCRIPTION
This is meant as a proof-of-concept, only. I did not want to spam the discussion in #36 with the diff.

This commit replaces the use of a temporary folder with a temporary file in the package directory itself. Since the generator will write to the package directory anyway, permissions should not be a problem. The import path of the target package is used as part of the filename to reduce the chance of overwriting an existing file.

For some reason running the generator this way does not trigger the error `import "foo" is a program, not an importable package`.