### PR TITLE
Allow modtime zero value

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -37,7 +37,7 @@ func Generate(input http.FileSystem, opt Options) error {
 	}
 
 	var toc toc
-	err = findAndWriteFiles(f, input, &toc)
+	err = findAndWriteFiles(f, input, &toc, opt.ZeroModTime)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ type dirInfo struct {
 // findAndWriteFiles recursively finds all the file paths in the given directory tree.
 // They are added to the given map as keys. Values will be safe function names
 // for each file, which will be used when generating the output code.
-func findAndWriteFiles(f *os.File, fs http.FileSystem, toc *toc) error {
+func findAndWriteFiles(f *os.File, fs http.FileSystem, toc *toc, zm bool) error {
 	walkFn := func(path string, fi os.FileInfo, r io.ReadSeeker, err error) error {
 		if err != nil {
 			log.Printf("can't stat file %q: %v\n", path, err)
@@ -140,10 +140,15 @@ func findAndWriteFiles(f *os.File, fs http.FileSystem, toc *toc) error {
 				return err
 			}
 
+			modtime := time.Time{}
+			if !zm {
+				modtime = fi.ModTime().UTC()
+			}
+
 			dir := &dirInfo{
 				Path:    path,
 				Name:    pathpkg.Base(path),
-				ModTime: fi.ModTime().UTC(),
+				ModTime: modtime,
 				Entries: entries,
 			}
 

--- a/options.go
+++ b/options.go
@@ -26,6 +26,9 @@ type Options struct {
 	// VariableComment is the comment of the http.FileSystem variable in the generated code.
 	// If left empty, it defaults to "{{.VariableName}} statically implements the virtual filesystem provided to vfsgen.".
 	VariableComment string
+
+	// Whether or not the modtime of the file should be saved. Default is to save the modtime.
+	ZeroModTime bool
 }
 
 // fillMissing sets default values for mandatory options that are left empty.


### PR DESCRIPTION
This prevents the vfsdata.go file from changing if the only
thing that has changed is the file modtime.

Resolves #26