### PR TITLE
generator: use go/format to format the output pre-writing to a file

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	"go/format"
 	"io"
 	"io/ioutil"
 	"log"
@@ -48,9 +49,15 @@ func Generate(input http.FileSystem, opt Options) error {
 		return err
 	}
 
+	// try and format the output
+	out := buf.Bytes()
+	if fmtOut, err := format.Source(out); err == nil {
+		out = fmtOut
+	}
+
 	// Write output file (all at once).
 	fmt.Println("writing", opt.Filename)
-	err = ioutil.WriteFile(opt.Filename, buf.Bytes(), 0644)
+	err = ioutil.WriteFile(opt.Filename, out, 0644)
 	return err
 }
 


### PR DESCRIPTION
Ensures output is automatically formatted correctly, according to the version of Go being used (because this ends up being called via `go run`)