### PR TITLE
return an error if input path is not readable

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -84,7 +84,7 @@ func findAndWriteFiles(buf *bytes.Buffer, fs http.FileSystem, toc *toc) error {
 	walkFn := func(path string, fi os.FileInfo, r io.ReadSeeker, err error) error {
 		if err != nil {
 			log.Printf("can't stat file %q: %v\n", path, err)
-			return nil
+			return err
 		}
 
 		switch fi.IsDir() {

--- a/generator.go
+++ b/generator.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	pathpkg "path"
@@ -83,7 +82,7 @@ type dirInfo struct {
 func findAndWriteFiles(buf *bytes.Buffer, fs http.FileSystem, toc *toc) error {
 	walkFn := func(path string, fi os.FileInfo, r io.ReadSeeker, err error) error {
 		if err != nil {
-			log.Printf("can't stat file %q: %v\n", path, err)
+			// Consider all errors reading the input filesystem as fatal.
 			return err
 		}
 

--- a/generator_test.go
+++ b/generator_test.go
@@ -97,3 +97,13 @@ func TestGenerate_buildAndGofmt(t *testing.T) {
 		}
 	}
 }
+
+// TestInvalidSourcePath ensures an error is returned in case a non-existent or non-readable input source
+// is used.
+func TestInvalidSourcePath(t *testing.T) {
+	var fs http.FileSystem = http.Dir("non-readable-source-path")
+
+	if err := vfsgen.Generate(fs, vfsgen.Options{}); err == nil {
+		t.Error("expected an error; got nil")
+	}
+}

--- a/generator_test.go
+++ b/generator_test.go
@@ -46,13 +46,21 @@ func TestGenerate_buildAndGofmt(t *testing.T) {
 	}()
 
 	tests := []struct {
-		filename string
-		fs       http.FileSystem
+		filename  string
+		fs        http.FileSystem
+		wantError func(error) bool // Nil function means want nil error.
 	}{
 		{
 			// Empty.
 			filename: "empty.go",
 			fs:       union.New(nil),
+		},
+		{
+			// Test that vfsgen.Generate returns an error when there is
+			// an error reading from the input filesystem.
+			filename:  "notexist.go",
+			fs:        http.Dir("notexist"),
+			wantError: os.IsNotExist,
 		},
 		{
 			// No compressed files.
@@ -81,12 +89,18 @@ func TestGenerate_buildAndGofmt(t *testing.T) {
 	for _, test := range tests {
 		filename := filepath.Join(tempDir, test.filename)
 
-		err = vfsgen.Generate(test.fs, vfsgen.Options{
+		err := vfsgen.Generate(test.fs, vfsgen.Options{
 			Filename:    filename,
 			PackageName: "test",
 		})
-		if err != nil {
-			t.Fatalf("vfsgen.Generate() failed: %v", err)
+		switch {
+		case test.wantError == nil && err != nil:
+			t.Fatalf("%s: vfsgen.Generate returned non-nil error: %v", test.filename, err)
+		case test.wantError != nil && !test.wantError(err):
+			t.Fatalf("%s: vfsgen.Generate returned wrong error: %v", test.filename, err)
+		}
+		if test.wantError != nil {
+			continue
 		}
 
 		if out, err := exec.Command("go", "build", filename).CombinedOutput(); err != nil {
@@ -95,20 +109,5 @@ func TestGenerate_buildAndGofmt(t *testing.T) {
 		if out, err := exec.Command("gofmt", "-d", "-s", filename).Output(); err != nil || len(out) != 0 {
 			t.Errorf("gofmt issue\nerr: %v\nout: %s", err, out)
 		}
-	}
-}
-
-// TestGenerateErrorOnInputError tests that vfsgen.Generate returns an error
-// when there is an error reading from the input filesystem.
-func TestGenerateErrorOnInputError(t *testing.T) {
-	badFS := http.Dir("notexist")
-	err := vfsgen.Generate(badFS, vfsgen.Options{
-		Filename: filepath.Join(os.TempDir(), "test_vfsdata.go"),
-	})
-	if err == nil {
-		t.Fatal("got error: nil, want: non-nil")
-	}
-	if got, want := os.IsNotExist(err), true; got != want {
-		t.Errorf("got os.IsNotExist(err): %v, want: %v", got, want)
 	}
 }

--- a/generator_test.go
+++ b/generator_test.go
@@ -98,12 +98,17 @@ func TestGenerate_buildAndGofmt(t *testing.T) {
 	}
 }
 
-// TestInvalidSourcePath ensures an error is returned in case a non-existent or non-readable input source
-// is used.
-func TestInvalidSourcePath(t *testing.T) {
-	var fs http.FileSystem = http.Dir("non-readable-source-path")
-
-	if err := vfsgen.Generate(fs, vfsgen.Options{}); err == nil {
-		t.Error("expected an error; got nil")
+// TestGenerateErrorOnInputError tests that vfsgen.Generate returns an error
+// when there is an error reading from the input filesystem.
+func TestGenerateErrorOnInputError(t *testing.T) {
+	badFS := http.Dir("notexist")
+	err := vfsgen.Generate(badFS, vfsgen.Options{
+		Filename: filepath.Join(os.TempDir(), "test_vfsdata.go"),
+	})
+	if err == nil {
+		t.Fatal("got error: nil, want: non-nil")
+	}
+	if got, want := os.IsNotExist(err), true; got != want {
+		t.Errorf("got os.IsNotExist(err): %v, want: %v", got, want)
 	}
 }


### PR DESCRIPTION
In case an input path does not exist or is not readable, a message is shown in the standard output but the actual error is not returned. For example, when running the following code

```go
err := vfsgen.Generate(invalidPath, vfsgen.Options{})
fmt.Println("err:", err)
if err != nil {
    os.Exit(1)
}
```
expected behaviour is

```shell
> go run generate.go
2018/08/21 15:55:50 can't stat file "/": open ../invalid/path: no such file or directory
err: open ../invalid/path: no such file or directory
exit status 1

> echo $?
1
```

while actual is

``` shell
> go run generate.go
2018/08/21 15:55:50 can't stat file "/": open ../invalid/path: no such file or directory
writing assets_vfsdata.go
err: <nil>

> echo $?
0
```

This PR leaves `log.Printf("can't stat file %q: %v\n", path, err)` line but can easily be removed :)