### PR TITLE
vfsgendev: look up source in the current module

### DIFF
--- a/cmd/vfsgendev/parse.go
+++ b/cmd/vfsgendev/parse.go
@@ -9,6 +9,7 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -65,11 +66,11 @@ func parseTagFlag(tagFlag string) (tag string, err error) {
 // lookupNameAndComment imports package using provided build context, and
 // returns the package name and variable comment.
 func lookupNameAndComment(bctx build.Context, importPath, variableName string) (packageName, variableComment string, err error) {
-	srcDir := ""
-	if abs, err := filepath.Abs("."); err == nil {
-		srcDir = abs
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", "", err
 	}
-	bpkg, err := bctx.Import(importPath, srcDir, 0)
+	bpkg, err := bctx.Import(importPath, wd, 0)
 	if err != nil {
 		return "", "", fmt.Errorf("can't import package %q: %v", importPath, err)
 	}

--- a/cmd/vfsgendev/parse.go
+++ b/cmd/vfsgendev/parse.go
@@ -16,6 +16,7 @@ import (
 )
 
 // parseSourceFlag parses the "-source" flag value. It must have "import/path".VariableName format.
+// It returns an error if the parsed import path is relative.
 func parseSourceFlag(sourceFlag string) (importPath, variableName string, err error) {
 	// Parse sourceFlag as a Go expression, albeit a strange one:
 	//

--- a/cmd/vfsgendev/parse.go
+++ b/cmd/vfsgendev/parse.go
@@ -60,7 +60,14 @@ func parseTagFlag(tagFlag string) (tag string, err error) {
 // lookupNameAndComment imports package using provided build context, and
 // returns the package name and variable comment.
 func lookupNameAndComment(bctx build.Context, importPath, variableName string) (packageName, variableComment string, err error) {
-	bpkg, err := bctx.Import(importPath, "", 0)
+	if build.IsLocalImport(importPath) {
+		return "", "", fmt.Errorf("refusing to use local import path %q", importPath)
+	}
+	srcDir := ""
+	if abs, err := filepath.Abs("."); err == nil {
+		srcDir = abs
+	}
+	bpkg, err := bctx.Import(importPath, srcDir, 0)
 	if err != nil {
 		return "", "", fmt.Errorf("can't import package %q: %v", importPath, err)
 	}


### PR DESCRIPTION
Currently vfsgendev only considers GOROOT and GOPATH when looking up the
source to use. This does not work as expected when running vfsgendev
within a go module, as introduced in Go 1.11.

Specifying the current directory (.) as the source directory for
`build.Import()`, allows the module logic to work when running inside a
go module.