### PR TITLE
Make the mod time optional

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -32,7 +32,7 @@ func Generate(input http.FileSystem, opt Options) error {
 	}
 
 	var toc toc
-	err = findAndWriteFiles(buf, input, &toc)
+	err = findAndWriteFiles(buf, input, &toc, opt)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ type dirInfo struct {
 // findAndWriteFiles recursively finds all the file paths in the given directory tree.
 // They are added to the given map as keys. Values will be safe function names
 // for each file, which will be used when generating the output code.
-func findAndWriteFiles(buf *bytes.Buffer, fs http.FileSystem, toc *toc) error {
+func findAndWriteFiles(buf *bytes.Buffer, fs http.FileSystem, toc *toc, opt Options) error {
 	walkFn := func(path string, fi os.FileInfo, r io.ReadSeeker, err error) error {
 		if err != nil {
 			// Consider all errors reading the input filesystem as fatal.
@@ -93,6 +93,9 @@ func findAndWriteFiles(buf *bytes.Buffer, fs http.FileSystem, toc *toc) error {
 				Name:             pathpkg.Base(path),
 				ModTime:          fi.ModTime().UTC(),
 				UncompressedSize: fi.Size(),
+			}
+			if opt.OmitModTime {
+				file.ModTime = time.Time{}
 			}
 
 			marker := buf.Len()
@@ -131,6 +134,9 @@ func findAndWriteFiles(buf *bytes.Buffer, fs http.FileSystem, toc *toc) error {
 				Name:    pathpkg.Base(path),
 				ModTime: fi.ModTime().UTC(),
 				Entries: entries,
+			}
+			if opt.OmitModTime {
+				dir.ModTime = time.Time{}
 			}
 
 			toc.dirs = append(toc.dirs, dir)

--- a/options.go
+++ b/options.go
@@ -26,6 +26,10 @@ type Options struct {
 	// VariableComment is the comment of the http.FileSystem variable in the generated code.
 	// If left empty, it defaults to "{{.VariableName}} statically implements the virtual filesystem provided to vfsgen.".
 	VariableComment string
+
+	// OmitModTime is whether files' modification time should be omitted.
+	// If set to true, all files' modification time will be the zero value of time.Time.
+	OmitModTime bool
 }
 
 // fillMissing sets default values for mandatory options that are left empty.

--- a/test/test_gen.go
+++ b/test/test_gen.go
@@ -19,6 +19,7 @@ func main() {
 		"folderA/file2.txt":              "Stuff in /folderA/file2.txt.",
 		"folderB/folderC/file3.txt":      "Stuff in /folderB/folderC/file3.txt.",
 		// TODO: Empty folder somehow?
+		// TODO: File with nonzero mod time somehow?
 		//"folder-empty/":                  "",
 	}))
 


### PR DESCRIPTION
Including the file modification time can make output non-reproducible in CI. That makes it difficult to use vfsgen in tandem with a check that runs go:generate and checks that no files changed.

This change adds an opt-out mechanism so that vfsgen's output will always be the same if the file contents have not changed.