### PR TITLE
ModTime option

### DIFF
--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package vfsgen
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // Options for vfsgen code generation.
@@ -26,6 +27,12 @@ type Options struct {
 	// VariableComment is the comment of the http.FileSystem variable in the generated code.
 	// If left empty, it defaults to "{{.VariableName}} statically implements the virtual filesystem provided to vfsgen.".
 	VariableComment string
+
+	// If non-zero, the files in the generated virtual filesystem will have this modification time,
+	// instead of the modification time of the original files on disk. This is useful if you are
+	// versioning the generated file and want to ignore changes to the modification time of the
+	// original files.
+	ModTime time.Time
 }
 
 // fillMissing sets default values for mandatory options that are left empty.


### PR DESCRIPTION
This adds a `ModTime` field to the `Options` struct, which lets the caller specify a modification time for all generated files. As the docstring states, this is useful in cases where the generated VFS file should change only if the actual file contents (ignoring modification time).

A concrete case is when the generated file is committed to a git repository and there is a CI job that runs `go generate` and verifies that `git diff` is empty. Prior to this change the CI job would always fail, because it would generate a VFS file with modification times inherited from the CI filesystem, resulting in a non-zero diff.