### PR TITLE
Add include/exclude options

### DIFF
--- a/options.go
+++ b/options.go
@@ -26,6 +26,14 @@ type Options struct {
 	// VariableComment is the comment of the http.FileSystem variable in the generated code.
 	// If left empty, it defaults to "{{.VariableName}} statically implements the virtual filesystem provided to vfsgen.".
 	VariableComment string
+
+	// IncludeRegex contains a regular expression of files to include, i.e. "\.[cC][sS][sS]$" to include only .css files
+	// If left empty, it defaults to "" (include all files)
+	Include string
+
+	// Exclude contains a regular expression of files to exclude, i.e. "\.[gG][oO]$" to exclude all .go files
+	// If left empty, it defaults to "" (exclude no files)
+	Exclude string
 }
 
 // fillMissing sets default values for mandatory options that are left empty.


### PR DESCRIPTION
I added this to allow me to place .go files in the root directory of my assets folder:
```
/static
 +- doc.go (mimics https://github.com/shurcooL/home/blob/master/assets/doc.go)
 +- static.go (mimics https://github.com/shurcooL/home/blob/master/assets/assets.go)
 +- assets_vfsdata.go
 |- /css 
 |  |...
 +- /js
    |...
```
If you approve of this PR, let me know if you want me to add these new options to https://github.com/shurcooL/vfsgen/blob/master/cmd/vfsgendev/generate.go, etc. in this PR, or create a new one.