### PR TITLE
Add ForceAllTypes to Options

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -49,11 +49,18 @@ func TestGenerate_buildAndGofmt(t *testing.T) {
 		filename  string
 		fs        http.FileSystem
 		wantError func(error) bool // Nil function means want nil error.
+		force     bool
 	}{
 		{
 			// Empty.
 			filename: "empty.go",
 			fs:       union.New(nil),
+		},
+		{
+			// Force all types.
+			filename: "forceall.go",
+			fs:       union.New(nil),
+			force:    true,
 		},
 		{
 			// Test that vfsgen.Generate returns an error when there is
@@ -90,8 +97,9 @@ func TestGenerate_buildAndGofmt(t *testing.T) {
 		filename := filepath.Join(tempDir, test.filename)
 
 		err := vfsgen.Generate(test.fs, vfsgen.Options{
-			Filename:    filename,
-			PackageName: "test",
+			Filename:      filename,
+			PackageName:   "test",
+			ForceAllTypes: test.force,
 		})
 		switch {
 		case test.wantError == nil && err != nil:

--- a/options.go
+++ b/options.go
@@ -26,6 +26,9 @@ type Options struct {
 	// VariableComment is the comment of the http.FileSystem variable in the generated code.
 	// If left empty, it defaults to "{{.VariableName}} statically implements the virtual filesystem provided to vfsgen.".
 	VariableComment string
+
+	// ForceAllTypes forces the generator to generate all vfsgen types.
+	ForceAllTypes bool
 }
 
 // fillMissing sets default values for mandatory options that are left empty.


### PR DESCRIPTION
Adds a `ForceAllTypes` member to Options, forcing the generation of both
the `vfsgen۰CompressedFileInfo` and `vfsgen۰FileInfo` types. Useful for
other using packages that need to ensure that both types are present.