### PR TITLE
ErrorOnPkgPkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ func main() {
 		PackageName:  "data",
 		BuildTags:    "!dev",
 		VariableName: "Assets",
+		ErrorOnPkgPkg: true,
 	})
 	if err != nil {
 		log.Fatalln(err)

--- a/generator.go
+++ b/generator.go
@@ -12,6 +12,7 @@ import (
 	pathpkg "path"
 	"sort"
 	"strconv"
+	"strings"
 	"text/template"
 	"time"
 
@@ -21,32 +22,35 @@ import (
 // Generate Go code that statically implements input filesystem,
 // write the output to a file specified in opt.
 func Generate(input http.FileSystem, opt Options) error {
+	if opt.ErrorOnPkgPkg {
+		rootDir, err := input.Open("/")
+		if err != nil {
+			return err
+		}
+		if strings.HasSuffix(fmt.Sprintf("%T", rootDir), "vfsgen۰Dir") {
+			return fmt.Errorf("trying to generate assest from a vfs packed asset")
+		}
+	}
 	opt.fillMissing()
-
 	// Use an in-memory buffer to generate the entire output.
 	buf := new(bytes.Buffer)
-
 	err := t.ExecuteTemplate(buf, "Header", opt)
 	if err != nil {
 		return err
 	}
-
 	var toc toc
 	err = findAndWriteFiles(buf, input, &toc)
 	if err != nil {
 		return err
 	}
-
 	err = t.ExecuteTemplate(buf, "DirEntries", toc.dirs)
 	if err != nil {
 		return err
 	}
-
 	err = t.ExecuteTemplate(buf, "Trailer", toc)
 	if err != nil {
 		return err
 	}
-
 	// Write output file (all at once).
 	fmt.Println("writing", opt.Filename)
 	err = ioutil.WriteFile(opt.Filename, buf.Bytes(), 0644)

--- a/generator.go
+++ b/generator.go
@@ -28,7 +28,7 @@ func Generate(input http.FileSystem, opt Options) error {
 			return err
 		}
 		if strings.HasSuffix(fmt.Sprintf("%T", rootDir), "vfsgen۰Dir") {
-			return fmt.Errorf("trying to generate assest from a vfs packed asset")
+			return fmt.Errorf("trying to generate assest from a vfs packed asset. Make sure the current build tag was used (eg go build -tags dev)")
 		}
 	}
 	opt.fillMissing()

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/shurcooL/vfsgen
+
+require (
+	github.com/shurcooL/httpfs v0.0.0-20181222201310-74dc9339e414
+	github.com/shurcooL/httpgzip v0.0.0-20180522190206-b1c53ac65af9
+	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd // indirect
+	golang.org/x/text v0.3.0 // indirect
+	golang.org/x/tools v0.0.0-20190213223815-88f95592de8c
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/shurcooL/httpfs v0.0.0-20181222201310-74dc9339e414 h1:IYVb70m/qpJGjyZV2S4qbdSDnsMl+w9nsQ2iQedf1HI=
+github.com/shurcooL/httpfs v0.0.0-20181222201310-74dc9339e414/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
+github.com/shurcooL/httpgzip v0.0.0-20180522190206-b1c53ac65af9 h1:fxoFD0in0/CBzXoyNhMTjvBZYW6ilSnTw7N7y/8vkmM=
+github.com/shurcooL/httpgzip v0.0.0-20180522190206-b1c53ac65af9/go.mod h1:919LwcH0M7/W4fcZ0/jy0qGght1GIhqyS/EgWGH2j5Q=
+golang.org/x/net v0.0.0-20190213061140-3a22650c66bd h1:HuTn7WObtcDo9uEEU7rEqL0jYthdXAmZ6PP+meazmaU=
+golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190213223815-88f95592de8c h1:Yl6vxDlVd3bqjIzcU0hIWfuQRe2vB1o6yaaORvz39bc=
+golang.org/x/tools v0.0.0-20190213223815-88f95592de8c/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/options.go
+++ b/options.go
@@ -26,6 +26,9 @@ type Options struct {
 	// VariableComment is the comment of the http.FileSystem variable in the generated code.
 	// If left empty, it defaults to "{{.VariableName}} statically implements the virtual filesystem provided to vfsgen.".
 	VariableComment string
+
+	// ErrorOnPkgPkg tells Generate to error if called with a FileSystem that is a vfs generated FS
+	ErrorOnPkgPkg bool
 }
 
 // fillMissing sets default values for mandatory options that are left empty.


### PR DESCRIPTION
This is a non breaking change.
If the option ErrorOnPkgPkg is true, then Generate errors if the input FileSystem is a vfs.

This is to stop errors when forgetting to swapping between dev and !dev.